### PR TITLE
Optional endpoints

### DIFF
--- a/CombinatorialCurve.py
+++ b/CombinatorialCurve.py
@@ -102,8 +102,16 @@ class CombCurve(object):
         self._genusCacheValid = False
 
     @property
+    def edgesWithVertices(self):
+        return {e for e in self.edges if not (e.vert1 is None or e.vert2 is None)}
+
+    @property
     def legs(self):
         return self._legs
+
+    @property
+    def legsWithVertices(self):
+        return {leg for leg in self.legs if not leg.root is None}
 
     # Control how legs are set
     # legs_ should be a set of legs
@@ -125,7 +133,7 @@ class CombCurve(object):
                 for vertex in sublist:
                     flattened_vertex_list.append(vertex)
 
-            self._vertexCache = set(flattened_vertex_list)
+            self._vertexCache = set(flattened_vertex_list) - {None}
             self._vertexCacheValid = True
 
         return self._vertexCache
@@ -136,18 +144,21 @@ class CombCurve(object):
     def vertexNumber(self):
         return len(self.vertices)
 
+
     # The number of edges is a read only property computed upon access
     # It is the number of edges
     @property
     def edgeNumber(self):
         return len(self.edges)
 
-
+    @property
+    def numEdgesWithVertices(self):
+        return len(self.edgesWithVertices)
 
     # The Betti number is a read only property computed upon access
     @property
     def bettiNumber(self):
-        return self.edgeNumber - self.vertexNumber + 1
+        return self.numEdgesWithVertices - self.vertexNumber + 1
 
     # Genus is a read only property computed upon access
     @property

--- a/StrictPiecewiseLinearFunction.py
+++ b/StrictPiecewiseLinearFunction.py
@@ -30,7 +30,7 @@ class StrictPiecewiseLinearFunction(object):
             assert l in self.functionValues
             # Ensure that each m(l) is an integer
             assert self.functionValues[l].is_integer()
-        for e in self.domain.edges:
+        for e in self.domain.edgesWithVertices:
             if e.length > 0.0:
                 # Ensure the function has integer slope
                 assert ((self.functionValues[e.vert1] - self.functionValues[e.vert2]) / e.length).is_integer()

--- a/tests.py
+++ b/tests.py
@@ -120,6 +120,9 @@ assert C.vertices == {v1}
 assert C.edgesWithVertices == {e1}
 assert C.edges == {e1, e2, e3}
 
+dict = {v1: 1.0}
+
+f = StrictPiecewiseLinearFunction(C, dict)
 
 
 

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,12 @@
 from CombinatorialCurve import *
 from StrictPiecewiseLinearFunction import *
 
+
+
+
+
+
+
 C = CombCurve("Example 3.5")
 v1 = vertex("v1", 0)
 v2 = vertex("v2", 0)
@@ -49,6 +55,16 @@ assert subdiv.edgeNumber == C.edgeNumber + 1
 
 
 
+
+
+
+
+
+
+
+
+
+
 C = CombCurve("Exercise 3.15 part 1")
 v1 = vertex("v1", 0)
 v2 = vertex("v2", 0)
@@ -66,6 +82,13 @@ assert C.genus == 5
 
 
 
+
+
+
+
+
+
+
 C = CombCurve("Exercise 3.15 parts 2 and 3")
 v1 = vertex("v1", 1)
 v2 = vertex("v2", 1)
@@ -77,6 +100,26 @@ assert C.bettiNumber == 0
 assert C.genus == 5
 for v in C.vertices:
     assert v.genus <= 1
+
+
+
+
+
+
+
+C = CombCurve("Curve with some vertices missing")
+v1 = vertex("v1", 1)
+e1 = edge("e1", 1.0, v1, v1)
+e2 = edge("e2", 1.0, v1, None)
+e3 = edge("e3", 1.0, None, None)
+C.edges = {e1, e2, e3}
+
+assert C.bettiNumber == 1
+assert C.genus == 2
+assert C.vertices == {v1}
+assert C.edgesWithVertices == {e1}
+assert C.edges == {e1, e2, e3}
+
 
 
 


### PR DESCRIPTION
This fixes some bugs caused by allowing `None` to be used as a vertex.